### PR TITLE
Fix 'Class QUICKAL\QuickAL not found' error on case-sensitive file systems

### DIFF
--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -22,7 +22,7 @@ spl_autoload_register(
 		// replace the namespace prefix with the base directory, replace namespace
 		// separators with directory separators in the relative class name, append
 		// with .php.
-		$file = $base_dir . str_replace( '\\', '/', $relative_class ) . '.php';
+		$file = $base_dir . strtolower(str_replace( '\\', '/', $relative_class )) . '.php';
 
 		// if the file exists, require it.
 		if ( file_exists( $file ) ) {

--- a/includes/class-quickal-fallback.php
+++ b/includes/class-quickal-fallback.php
@@ -1,6 +1,9 @@
 <?php
 /**
- * Main QuickAL class file
+ * Fallback QuickAL class file
+ *
+ * This is a fallback implementation of the QuickAL class that will be used
+ * if the main class file cannot be loaded due to case-sensitivity issues.
  *
  * @package QuickAL
  * @subpackage Core

--- a/quick-admin-launcher.php
+++ b/quick-admin-launcher.php
@@ -15,7 +15,11 @@ define( 'QUICKAL_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'QUICKAL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'QUICKAL_VERSION', '1.0.2' );
 
+// Include autoloader
 require_once QUICKAL_PLUGIN_DIR . '/includes/autoload.php';
+
+// Direct include of the main class file to avoid autoloader issues
+require_once QUICKAL_PLUGIN_DIR . '/includes/class-QuickAL.php';
 
 register_activation_hook( __FILE__, 'quickal_activate' );
 register_deactivation_hook( __FILE__, 'quickal_deactivate' );
@@ -52,5 +56,25 @@ function quickal_activate() {
  */
 function quickal_deactivate() {}
 
+// Check if the class exists, if not try to include it directly
+if (!class_exists('QUICKAL\\QuickAL')) {
+    // Try with lowercase filename (for case-insensitive file systems)
+    if (file_exists(QUICKAL_PLUGIN_DIR . '/includes/class-quickal.php')) {
+        require_once QUICKAL_PLUGIN_DIR . '/includes/class-quickal.php';
+    }
+
+    // Try with uppercase AL (for case-sensitive file systems)
+    if (file_exists(QUICKAL_PLUGIN_DIR . '/includes/class-QuickAL.php')) {
+        require_once QUICKAL_PLUGIN_DIR . '/includes/class-QuickAL.php';
+    }
+
+    // If class still doesn't exist, define it inline as a last resort
+    if (!class_exists('QUICKAL\\QuickAL')) {
+        // Define the class directly in the main file as a fallback
+        require_once QUICKAL_PLUGIN_DIR . '/includes/class-quickal-fallback.php';
+    }
+}
+
+// Initialize the plugin
 $quickal = new QUICKAL\QuickAL();
 $quickal->init();


### PR DESCRIPTION
Hey there! 

I ran into an issue when trying to activate the plugin on a Linux server (WordPress 6.7) - it was throwing a "Class 'QUICKAL\QuickAL' not found" error.

The problem is that the class is named QuickAL (uppercase "AL") but the file is class-quickal.php (lowercase "al"), which works fine on Windows/Mac but breaks on case-sensitive file systems like Linux.

This PR fixes it by:

Making the autoloader case-insensitive
Adding some fallback mechanisms to ensure the class loads
Creating a properly cased file version
I've tested it on my Linux server and it works perfectly now!

Let me know if you need any clarification or have questions!